### PR TITLE
printstyled specialisation for AnnotatedIOBuffer

### DIFF
--- a/src/legacy.jl
+++ b/src/legacy.jl
@@ -6,7 +6,7 @@
 
 module Legacy
 
-using ..StyledStrings: SimpleColor, Face, loadface!
+using ..StyledStrings: SimpleColor, Face, loadface!, face!
 
 """
 A mapping from 256-color codes indicies to 8-bit colours.
@@ -110,6 +110,20 @@ function load_env_colors!()
             end
         end
     end
+end
+
+function Base.printstyled(io::Base.AnnotatedIOBuffer, msg...;
+                          bold::Bool=false, italic::Bool=false, underline::Bool=false,
+                          blink::Bool=false, reverse::Bool=false, hidden::Bool=false,
+                          color::Union{Symbol, Int}=:normal)
+    str = Base.annotatedstring(msg...)
+    bold && face!(str, :bold)
+    italic && face!(str, :italic)
+    underline && face!(str, :underline)
+    reverse && face!(str, Face(inverse=true))
+    color !== :normal && face!(str, Face(foreground=legacy_color(color)))
+    write(io, str)
+    nothing
 end
 
 end


### PR DESCRIPTION
This allows for providing an AnnotatedIOBuffer to various IO-accepting printing functions (e.g. show, showerror) and obtaining the annotations that would be formed from straightforwardly switching to StyledStrings.

Requires https://github.com/JuliaLang/julia/pull/51807

-----

![image](https://github.com/JuliaLang/StyledStrings.jl/assets/20903656/6b2481ba-e7ed-408f-9dd3-f560264cf647)
