### PR TITLE
Disable CI for older versions of Julia

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,8 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
-          - '1'
+          # - '1.0'
+          # - '1.6'
+          # - '1'
           - 'nightly'
         os:
           - ubuntu-latest


### PR DESCRIPTION
StyledStrings.jl does not currently support older versions of Julia. These lines can be uncommented when that support is added.