### PR TITLE
add `repl_prompt_beep` face

### DIFF
--- a/src/faces.jl
+++ b/src/faces.jl
@@ -329,6 +329,7 @@ const FACES = let default = Dict{Symbol, Face}(
     :repl_prompt_help => Face(inherit=[:yellow, :repl_prompt]),
     :repl_prompt_shell => Face(inherit=[:red, :repl_prompt]),
     :repl_prompt_pkg => Face(inherit=[:blue, :repl_prompt]),
+    :repl_prompt_beep => Face(inherit=[:shadow, :repl_prompt]),
     )
     (; default, current=ScopedValue(copy(default)), lock=ReentrantLock())
 end


### PR DESCRIPTION
This face is used in the repl to alert a user that an action had to effect, for example when a user presses `backspace` when a user hasn't input anything, or uses `Tab` for completion and there are no completion suggestions.