### PR TITLE
Setting the terminal colour to :default is special

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -111,6 +111,8 @@ function termcolor(io::IO, color::SimpleColor, category::Char)
         else
             termcolor8bit(io, color.value, category)
         end
+    elseif color.value === :default
+        print(io, "\e[", category, "9m")
     elseif (fg = get(FACES.current[], color.value, getface()).foreground) != SimpleColor(color.value)
         termcolor(io, fg, category)
     else


### PR DESCRIPTION
It is worth taking note of the fact that the "default" colour in a
terminal can be set with the -9 ANSI codes. Without this, dodgy control
codes can be emitted when the current default face is changed, resulting
in visual artifacts.