### PR TITLE
Restrict the Base docstrings included in the docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -184,7 +184,7 @@ StyledStrings.@styled_str
 StyledStrings.Face
 StyledStrings.addface!
 StyledStrings.SimpleColor
-Base.parse
-Base.tryparse
-Base.merge
+Base.parse(::Type{StyledStrings.SimpleColor}, ::String)
+Base.tryparse(::Type{StyledStrings.SimpleColor}, ::String)
+Base.merge(::StyledStrings.Face, ::StyledStrings.Face)
 ```


### PR DESCRIPTION
This should resolve the current conflict with the docstrings from Base's
documentation. 🤞