### PR TITLE
Fix showing AnnotatedChar with colour

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -268,7 +268,7 @@ function show(io::IO, c::AnnotatedChar)
     if get(io, :color, false) == true
         out = IOBuffer()
         show(out, c.char)
-        print(io, ''', AnnotatedString(String(take!(out)[2:end-1]), c.annotations), ''')
+        print(io, ''', AnnotatedString(String(take!(out)[2:end-1]), map(a -> (1:ncodeunits(c), a), c.annotations)), ''')
     else
         show(io, c.char)
     end


### PR DESCRIPTION
This method was overlooked when the `AnnotatedString(::String, ::Vector{Pair{Symbol, <:Any}})` constructor was removed.