### PR TITLE
Call escape_raw_string to make parsing more predictable

### DIFF
--- a/src/stylemacro.jl
+++ b/src/stylemacro.jl
@@ -84,9 +84,11 @@ inheritval = whitespace, ':'?, symbol ;
 ```
 """
 macro styled_str(raw_content::String)
-    #------------------
-    # Helper functions
-    #------------------
+    # First undo the transforms of the parser, (assuming the input was entered
+    # with single `styled""` markers so this transform is unambiguously
+    # reversible and not as `@styled_str "."` or `styled"""."""`), since the
+    # `unescape_string` transforms will be a superset of those transforms
+    raw_content = Base.escape_raw_string(raw_content)
 
     # If this were a module, I'd define the following struct.
 
@@ -127,6 +129,10 @@ macro styled_str(raw_content::String)
         ("black", "red", "green", "yellow", "blue", "magenta", "cyan", "white",
          "grey", "gray", "bright_black", "bright_red", "bright_green", "bright_yellow",
          "bright_blue", "bright_magenta", "bright_cyan", "bright_white")
+
+    #------------------
+    # Helper functions
+    #------------------
 
     function styerr!(state, message, position::Union{Nothing, Int}=nothing, hint::String="around here")
         if !isnothing(position) && position < 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,6 +207,14 @@ end
             @macroexpand styled"{(foreground=$color):val}"
     end
 
+    # Trailing (and non-trailing) Backslashes
+    @test String(styled"\\") == "\\"
+    @test String(styled"\\\\") == "\\\\"
+    @test String(styled"\\\\\\") == "\\\\\\"
+    @test String(styled".\\") == ".\\"
+    @test String(styled".\\\\") == ".\\\\"
+    @test String(styled".\\\\\\") == ".\\\\\\"
+
     # newlines
     normal = "abc\
               def"


### PR DESCRIPTION
The advantage here is that you don't escape it twice, so that `styled"\\"` doesn't need double the number of `\\` each time to get one more `\` at the end (the downside is that less common forms such as `@styled_str "\\"` still apply the `unescape_string` call twice and we cannot catch that)
```
julia> styled""
""

julia> styled"\\"
"\\"

julia> styled"\\\\"
"\\"

julia> styled"\\\\\\"
"\\\\"

julia> styled"\\\\\\\\"
"\\\\"
```