### PR TITLE
Adjust to changed annotations function return form

### DIFF
--- a/src/faces.jl
+++ b/src/faces.jl
@@ -537,7 +537,7 @@ getface() = FACES.current[][:default]
 Get the merged [`Face`](@ref) that applies to `s` at index `i`.
 """
 getface(s::AnnotatedString, i::Integer) =
-    getface(annotations(s, i))
+    getface(map(last, annotations(s, i)))
 
 """
     getface(c::AnnotatedChar)

--- a/src/regioniterator.jl
+++ b/src/regioniterator.jl
@@ -46,10 +46,10 @@ function eachregion(s::AnnotatedString, region::UnitRange{Int}=firstindex(s):las
                                             for region in first.(s.annotations)) |>
                                                 unique |> sort)
     isempty(changepoints) &&
-        return RegionIterator(s.string, [region], [annotations(s, first(region))])
+        return RegionIterator(s.string, [region], [map(last, annotations(s, first(region)))])
     function registerchange!(start, stop)
         push!(regions, start:stop)
-        push!(annots, annotations(s, start))
+        push!(annots, map(last, annotations(s, start)))
     end
     if first(region) < first(changepoints)
         registerchange!(first(region), prevind(s, first(changepoints)))


### PR DESCRIPTION
For consistency, calling `annotations` on an AnnotatedString, whether an
index or range is specified, now always returns a vector of
region-annotation tuples.

Previously, when an index was specified, only the annotations would be
returned. Thus, code that relies on this previous behaviour must now
apply `last` to each element of the returned vector.