### PR TITLE
Load no faces.toml when the DEPOT_PATH is empty

### DIFF
--- a/src/StyledStrings.jl
+++ b/src/StyledStrings.jl
@@ -18,8 +18,10 @@ include("legacy.jl")
 using .StyledMarkup
 
 function __init__()
-    userfaces = joinpath(first(DEPOT_PATH), "config", "faces.toml")
-    isfile(userfaces) && loaduserfaces!(userfaces)
+    if !isempty(DEPOT_PATH)
+        userfaces = joinpath(first(DEPOT_PATH), "config", "faces.toml")
+        isfile(userfaces) && loaduserfaces!(userfaces)
+    end
     Legacy.load_env_colors!()
 end
 


### PR DESCRIPTION
In rare cases, it is possible that the DEPOT_PATH could be empty. As
such, the assumption that first(DEPOT_PATH) will produce a valid value
needs to be removed, in which case we simply won't automatically load a
user faces.toml.