### PR TITLE
Use a function over a closure to handle poor inference

### DIFF
--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -49,6 +49,7 @@ StyledStrings.StyledMarkup.escaped!
 StyledStrings.StyledMarkup.interpolated!
 StyledStrings.StyledMarkup.readexpr!
 StyledStrings.StyledMarkup.skipwhitespace!
+StyledStrings.StyledMarkup.read_while!
 StyledStrings.StyledMarkup.begin_style!
 StyledStrings.StyledMarkup.end_style!
 StyledStrings.StyledMarkup.read_annotation!


### PR DESCRIPTION
The previous code pattern using `takewhile` relied on Julia's type inference to produce correct results. In particular, it relied on `takewhile(f, x) |> collect` to correctly infer to `Vector{<:Tuple{Char, Any}}`. However, type inference in Julia is an optimization, and should not be relied on to produce the correct answer.
Instead, use a normal function to replace the functional style of programming.

Edit: I haven't been able to run tests locally, so this might not work as-is. See #63 