### PR TITLE
Add types to some comprehensions

### DIFF
--- a/src/regioniterator.jl
+++ b/src/regioniterator.jl
@@ -46,7 +46,7 @@ function eachregion(s::AnnotatedString, region::UnitRange{Int}=firstindex(s):las
                                             for region in first.(s.annotations)) |>
                                                 unique |> sort)
     isempty(changepoints) &&
-        return RegionIterator(s.string, [region], [map(last, annotations(s, first(region)))])
+        return RegionIterator(s.string, UnitRange{Int}[region], Vector{Pair{Symbol, Any}}[map(last, annotations(s, first(region)))])
     function registerchange!(start, stop)
         push!(regions, start:stop)
         push!(annots, map(last, annotations(s, start)))


### PR DESCRIPTION
Currently the correctness of this depends on the exact typejoin logic for comprehensions. That's probably reasonably safe, but it can break when developing Base, and since this is a stdlib, let's be a good citizen and annotate the types.