### PR TITLE
Treat printing as more than a nothing-return write

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -253,6 +253,11 @@ write(io::IO, s::Union{<:AnnotatedString, SubString{<:AnnotatedString}}) =
     _ansi_writer(io, s, write)::Int
 
 print(io::IO, s::Union{<:AnnotatedString, SubString{<:AnnotatedString}}) =
+    (_ansi_writer(io, s, print); nothing)
+
+# We need to make sure that printing to an `AnnotatedIOBuffer` calls `write` not `print`
+# so we get the specialised handling that `_ansi_writer` doesn't provide.
+print(io::Base.AnnotatedIOBuffer, s::Union{<:AnnotatedString, SubString{<:AnnotatedString}}) =
     (write(io, s); nothing)
 
 escape_string(io::IO, s::Union{<:AnnotatedString, SubString{<:AnnotatedString}},


### PR DESCRIPTION
As raised in https://github.com/JuliaLang/julia/issues/55198, once we look at `AbstractString` types outside of Core/Base, their `print` methods can be meaningfully different to `write` + returning `nothing`.

As such, instead of delegating printing to `write`, we need to call `_ansi_writer` asking it to use the `print` function.