### PR TITLE
do not `import` methods that are not extended and use explicit module prefix for methods that are imported

### DIFF
--- a/src/StyledStrings.jl
+++ b/src/StyledStrings.jl
@@ -2,9 +2,8 @@
 
 module StyledStrings
 
-import Base: AnnotatedString, AnnotatedChar, annotations, annotate!,
-    annotatedstring, convert, merge, show, print, write,
-    ScopedValue, with, @with
+using Base: AnnotatedString, AnnotatedChar, annotations, annotate!, annotatedstring,
+      ScopedValue, with, @with
 
 export @styled_str
 public Face, addface!, withfaces, styled, SimpleColor

--- a/src/faces.jl
+++ b/src/faces.jl
@@ -27,9 +27,9 @@ end
 SimpleColor(r::Integer, g::Integer, b::Integer) = SimpleColor((; r=UInt8(r), g=UInt8(g), b=UInt8(b)))
 SimpleColor(rgb::UInt32) = SimpleColor(reverse(reinterpret(UInt8, [rgb]))[2:end]...)
 
-convert(::Type{SimpleColor}, (; r, g, b)::RGBTuple) = SimpleColor((; r, g, b))
-convert(::Type{SimpleColor}, namedcolor::Symbol) = SimpleColor(namedcolor)
-convert(::Type{SimpleColor}, rgb::UInt32) = SimpleColor(rgb)
+Base.convert(::Type{SimpleColor}, (; r, g, b)::RGBTuple) = SimpleColor((; r, g, b))
+Base.convert(::Type{SimpleColor}, namedcolor::Symbol) = SimpleColor(namedcolor)
+Base.convert(::Type{SimpleColor}, rgb::UInt32) = SimpleColor(rgb)
 
 """
     tryparse(::Type{SimpleColor}, rgb::String)
@@ -175,7 +175,7 @@ Base.copy(f::Face) =
          f.foreground, f.background, f.underline,
          f.strikethrough, f.inverse, copy(f.inherit))
 
-function show(io::IO, ::MIME"text/plain", color::SimpleColor)
+function Base.show(io::IO, ::MIME"text/plain", color::SimpleColor)
     skiptype = get(io, :typeinfo, nothing) === SimpleColor
     skiptype || show(io, SimpleColor)
     skiptype || print(io, '(')
@@ -195,7 +195,7 @@ function show(io::IO, ::MIME"text/plain", color::SimpleColor)
     nothing
 end
 
-function show(io::IO, color::SimpleColor)
+function Base.show(io::IO, color::SimpleColor)
     show(io, SimpleColor)
     print(io, '(')
     if color.value isa RGBTuple
@@ -210,7 +210,7 @@ function show(io::IO, color::SimpleColor)
     print(io, ')')
 end
 
-function show(io::IO, ::MIME"text/plain", face::Face)
+function Base.show(io::IO, ::MIME"text/plain", face::Face)
     if get(io, :compact, false)::Bool
         show(io, Face)
         if get(io, :color, false)::Bool
@@ -285,7 +285,7 @@ function show(io::IO, ::MIME"text/plain", face::Face)
     end
 end
 
-function show(io::IO, face::Face)
+function Base.show(io::IO, face::Face)
     show(IOContext(io, :compact => true), MIME("text/plain"), face)
 end
 
@@ -489,7 +489,7 @@ withfaces(f) = f()
 Merge the properties of the `initial` face and `others`, with
 later faces taking priority.
 """
-function merge(a::Face, b::Face)
+function Base.merge(a::Face, b::Face)
     if isempty(b.inherit)
         Face(ifelse(isnothing(b.font),          a.font,          b.font),
              if isnothing(b.height)      a.height
@@ -515,7 +515,7 @@ function merge(a::Face, b::Face)
     end
 end
 
-merge(a::Face, b::Face, others::Face...) = merge(merge(a, b), others...)
+Base.merge(a::Face, b::Face, others::Face...) = merge(merge(a, b), others...)
 
 ## Getting the combined face from a set of properties ##
 
@@ -647,7 +647,7 @@ Load all faces declared in the Faces.toml file `tomlfile`.
 """
 loaduserfaces!(tomlfile::String) = loaduserfaces!(Base.parsed_toml(tomlfile))
 
-function convert(::Type{Face}, spec::Dict)
+function Base.convert(::Type{Face}, spec::Dict)
     Face(if haskey(spec, "font") && spec["font"] isa String
              spec["font"] end,
          if haskey(spec, "height") && (spec["height"] isa Int || spec["height"] isa Float64)

--- a/src/io.jl
+++ b/src/io.jl
@@ -250,22 +250,22 @@ function _ansi_writer(io::IO, s::Union{<:AnnotatedString, SubString{<:AnnotatedS
     end
 end
 
-write(io::IO, s::Union{<:AnnotatedString, SubString{<:AnnotatedString}}) =
+Base.write(io::IO, s::Union{<:AnnotatedString, SubString{<:AnnotatedString}}) =
     _ansi_writer(io, s, write)::Int
 
-print(io::IO, s::Union{<:AnnotatedString, SubString{<:AnnotatedString}}) =
+Base.print(io::IO, s::Union{<:AnnotatedString, SubString{<:AnnotatedString}}) =
     (_ansi_writer(io, s, print); nothing)
 
 # We need to make sure that printing to an `AnnotatedIOBuffer` calls `write` not `print`
 # so we get the specialised handling that `_ansi_writer` doesn't provide.
-print(io::Base.AnnotatedIOBuffer, s::Union{<:AnnotatedString, SubString{<:AnnotatedString}}) =
+Base.print(io::Base.AnnotatedIOBuffer, s::Union{<:AnnotatedString, SubString{<:AnnotatedString}}) =
     (write(io, s); nothing)
 
 escape_string(io::IO, s::Union{<:AnnotatedString, SubString{<:AnnotatedString}},
               esc = ""; keep = ()) =
     (_ansi_writer(io, s, (io, s) -> escape_string(io, s, esc; keep)); nothing)
 
-function write(io::IO, c::AnnotatedChar)
+function Base.write(io::IO, c::AnnotatedChar)
     if get(io, :color, false) == true
         termstyle(io, getface(c), getface())
         bytes = write(io, c.char)
@@ -276,9 +276,9 @@ function write(io::IO, c::AnnotatedChar)
     end
 end
 
-print(io::IO, c::AnnotatedChar) = (write(io, c); nothing)
+Base.print(io::IO, c::AnnotatedChar) = (write(io, c); nothing)
 
-function show(io::IO, c::AnnotatedChar)
+function Base.show(io::IO, c::AnnotatedChar)
     if get(io, :color, false) == true
         out = IOBuffer()
         show(out, c.char)
@@ -288,7 +288,7 @@ function show(io::IO, c::AnnotatedChar)
     end
 end
 
-function write(io::IO, aio::Base.AnnotatedIOBuffer)
+function Base.write(io::IO, aio::Base.AnnotatedIOBuffer)
     if get(io, :color, false) == true
         # This does introduce an overhead that technically
         # could be avoided, but I'm not sure that it's currently
@@ -430,7 +430,7 @@ function htmlstyle(io::IO, face::Face, lastface::Face=getface())
     print(io, "\">")
 end
 
-function show(io::IO, ::MIME"text/html", s::Union{<:AnnotatedString, SubString{<:AnnotatedString}}; wrap::Symbol=:pre)
+function Base.show(io::IO, ::MIME"text/html", s::Union{<:AnnotatedString, SubString{<:AnnotatedString}}; wrap::Symbol=:pre)
     htmlescape(str) = replace(str, '&' => "&amp;", '<' => "&lt;", '>' => "&gt;")
     buf = IOBuffer() # Avoid potential overhead in repeatadly printing a more complex IO
     wrap == :none ||


### PR DESCRIPTION
This avoids accidentally extending methods and makes it more clear what methods are doing overloads
