### PR TITLE
avoid creating a new `Face` in `get` calls when `FACES` has that face available

### DIFF
--- a/src/faces.jl
+++ b/src/faces.jl
@@ -470,7 +470,7 @@ function withfaces(f, keyvals_itr)
         if face isa Face
             newfaces[name] = face
         elseif face isa Symbol
-            newfaces[name] = get(FACES.current[], face, Face())
+            newfaces[name] = get(Face, FACES.current[], face)
         elseif face isa Vector{Symbol}
             newfaces[name] = Face(inherit=face)
         elseif haskey(newfaces, name)
@@ -517,7 +517,7 @@ function Base.merge(a::Face, b::Face)
         b_noinherit = Face(
             b.font, b.height, b.weight, b.slant, b.foreground, b.background,
             b.underline, b.strikethrough, b.inverse, Symbol[])
-        b_inheritance = map(fname -> get(FACES.current[], fname, Face()), Iterators.reverse(b.inherit))
+        b_inheritance = map(fname -> get(Face, FACES.current[], fname), Iterators.reverse(b.inherit))
         b_resolved = merge(foldl(merge, b_inheritance), b_noinherit)
         merge(a, b_resolved)
     end
@@ -529,7 +529,7 @@ Base.merge(a::Face, b::Face, others::Face...) = merge(merge(a, b), others...)
 
 # Putting these inside `getface` causes the julia compiler to box it
 _mergedface(face::Face) = face
-_mergedface(face::Symbol) = get(FACES.current[], face, Face())
+_mergedface(face::Symbol) = get(Face, FACES.current[], face)
 _mergedface(faces::Vector) = mapfoldl(_mergedface, merge, Iterators.reverse(faces))
 
 """
@@ -558,7 +558,7 @@ function getface(annotations::Vector{Pair{Symbol, Any}})
 end
 
 getface(face::Face) = merge(FACES.current[][:default], merge(Face(), face))
-getface(face::Symbol) = getface(get(FACES.current[], face, Face()))
+getface(face::Symbol) = getface(get(Face, FACES.current[], face))
 
 """
     getface()


### PR DESCRIPTION
The `get(f::Function, collection, key)` method is typically better than `get(collection, key, f())` when `f` is not trivial. This avoids calling it unless it is actually needed.

Made on top of https://github.com/JuliaLang/StyledStrings.jl/pull/75 to avoid a merge conflict.

Before (same benchmark as in #75):

```
9.508 ms (290571 allocations: 18.78 MiB)
```

After

```
  8.243 ms (201949 allocations: 16.58 MiB)
```