### PR TITLE
use ternery instead of `ifelse` since ifelse force evaluation of the RHS

### DIFF
--- a/src/faces.jl
+++ b/src/faces.jl
@@ -499,19 +499,20 @@ function Base.merge(a::Face, b::Face)
         # to narrow the types in e.g. `aheight * bheight`
         aheight = a.height
         bheight = b.height
-        Face(ifelse(isnothing(b.font),          a.font,          b.font),
-             if isnothing(bheight)      aheight
-             elseif isnothing(aheight)  bheight
-             elseif bheight isa Int     bheight
-             elseif aheight isa Int     round(Int, aheight * bheight)
-             else aheight * bheight end,
-             ifelse(isnothing(b.weight),        a.weight,        b.weight),
-             ifelse(isnothing(b.slant),         a.slant,         b.slant),
-             ifelse(isnothing(b.foreground),    a.foreground,    b.foreground),
-             ifelse(isnothing(b.background),    a.background,    b.background),
-             ifelse(isnothing(b.underline),     a.underline,     b.underline),
-             ifelse(isnothing(b.strikethrough), a.strikethrough, b.strikethrough),
-             ifelse(isnothing(b.inverse),       a.inverse,       b.inverse),
+        abheight = if isnothing(bheight) aheight
+        elseif isnothing(aheight) bheight
+        elseif bheight isa Int bheight
+        elseif aheight isa Int round(Int, aheight * bheight)
+        else aheight * bheight end
+        Face(if isnothing(b.font)          a.font          else b.font          end,
+             abheight,
+             if isnothing(b.weight)        a.weight        else b.weight        end,
+             if isnothing(b.slant)         a.slant         else b.slant         end,
+             if isnothing(b.foreground)    a.foreground    else b.foreground    end,
+             if isnothing(b.background)    a.background    else b.background    end,
+             if isnothing(b.underline)     a.underline     else b.underline     end,
+             if isnothing(b.strikethrough) a.strikethrough else b.strikethrough end,
+             if isnothing(b.inverse)       a.inverse       else b.inverse       end,
              a.inherit)
     else
         b_noinherit = Face(


### PR DESCRIPTION
Made on top of #77 to avoid some merge conflicts and have up to date benchmarks.

I was looking at why the following benchmark allocates:

```julia-repl
julia> using StyledStrings

julia> styles = Pair{Symbol, Any}[:face => :green]
1-element Vector{Pair{Symbol, Any}}:
 :face => :green

julia> face = StyledStrings.getface(styles);

julia> using BenchmarkTools

julia> @btime merge($face, $face)
  19.266 ns (2 allocations: 32 bytes)
```

With the following PR we instead get

```
julia> @btime merge($face, $face)
  13.388 ns (0 allocations: 0 bytes)
```

The benchmark in #75 

goes from

```
  8.654 ms (202611 allocations: 16.62 MiB)
```

to

```
  7.972 ms (148360 allocations: 15.72 MiB)
```

Not a huge speedup but quite a big reduction in allocations which might be useful as other things improve.

I am not 100% sure why this is needed but I typically find the compiler optimizes better with ternary `?` over `ifelse`.