### PR TITLE
Load user-customisations lazily

### DIFF
--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -25,6 +25,7 @@ StyledStrings.resetfaces!
 StyledStrings.termcolor
 StyledStrings.termcolor24bit
 StyledStrings.termcolor8bit
+StyledStrings.load_customisations!
 ```
 
 ## Styled Markup parsing

--- a/src/StyledStrings.jl
+++ b/src/StyledStrings.jl
@@ -16,12 +16,29 @@ include("legacy.jl")
 
 using .StyledMarkup
 
-function __init__()
+const HAVE_LOADED_CUSTOMISATIONS = Base.Threads.Atomic{Bool}(false)
+
+"""
+    load_customisations!(; force::Bool=false)
+
+Load customisations from the user's `faces.toml` file, if it exists as well as
+the current environment.
+
+This function should be called before producing any output in situations where
+the user's customisations should be considered.
+
+Unless `force` is set, customisations are only applied when this function is
+called for the first time, and subsequent calls are a no-op.
+"""
+function load_customisations!(; force::Bool=false)
+    !force && HAVE_LOADED_CUSTOMISATIONS[] && return
     if !isempty(DEPOT_PATH)
         userfaces = joinpath(first(DEPOT_PATH), "config", "faces.toml")
         isfile(userfaces) && loaduserfaces!(userfaces)
     end
     Legacy.load_env_colors!()
+    HAVE_LOADED_CUSTOMISATIONS[] = true
+    nothing
 end
 
 if Base.generating_output()


### PR DESCRIPTION
This is primarily motivated by reducing the amount of work that trimming is unable to remove.

It will require applications (by which I mean the actual thing that uses `StyledStrings`, for example the REPL) to call `load_customisations!` itself. If there's a good spot to add that so it automatically gets done "at the right time, when appropriate to do so" that would be even better, but I'm not sure there's an obvious spot that can be done without the potential for headaches (e.g. what if it comes up within a `withfaces` call).

For now at least, perhaps this is a reasonable compromise.