### PR TITLE
Load ScopedValues symbols from their source

### DIFF
--- a/src/StyledStrings.jl
+++ b/src/StyledStrings.jl
@@ -2,8 +2,8 @@
 
 module StyledStrings
 
-using Base: AnnotatedString, AnnotatedChar, annotations, annotate!, annotatedstring,
-      ScopedValue, with, @with
+using Base: AnnotatedString, AnnotatedChar, annotations, annotate!, annotatedstring
+using Base.ScopedValues: ScopedValue, with, @with
 
 export @styled_str
 public Face, addface!, withfaces, styled, SimpleColor


### PR DESCRIPTION
Loading `@with` from Base is accessing internals because `@with` is not a public symbol in Base.

See also: https://github.com/JuliaLang/julia/pull/55095#issuecomment-2226254429