### PR TITLE
Consistent Face hashes

### DIFF
--- a/src/faces.jl
+++ b/src/faces.jl
@@ -174,6 +174,9 @@ Base.:(==)(a::Face, b::Face) =
     getfield.(Ref(a), fieldnames(Face)) ==
     getfield.(Ref(b), fieldnames(Face))
 
+Base.hash(f::Face, h::UInt) =
+    mapfoldr(Base.Fix1(getfield, f), hash, fieldnames(Face), init=hash(Face, h))
+
 Base.copy(f::Face) =
     Face(f.font, f.height, f.weight, f.slant,
          f.foreground, f.background, f.underline,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -257,6 +257,15 @@ end
         @test getface(:f).foreground.value == :blue
         StyledStrings.resetfaces!()
     end
+    # Equality/hashing equivalence
+    let testfaces = [Face(foreground=:blue),
+                     Face(background=:blue),
+                     Face(inherit=:something),
+                     Face(inherit=:something)]
+        for f1 in testfaces, f2 in testfaces
+            @test (f1 == f2) == (hash(f1) == hash(f2))
+        end
+    end
     # Pretty display
     @test sprint(show, MIME("text/plain"), getface()) |> choppkg ==
         """


### PR DESCRIPTION
Since we implement a custom equality function, it seems nice to have it so that `Face` objects that are equal `hash` equally too.

I'm not aware of anybody using this, but it seems nice to have. and it's just a 2-liner.