### PR TITLE
Fix markdown syntax in "Mark API as experimental"

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,8 +1,8 @@
 # [StyledStrings](@id stdlib-styledstrings)
 
 !!! note
-  The API for StyledStrings and AnnotatedStrings is considered experimental and is subject to change between
-  Julia versions.
+    The API for StyledStrings and AnnotatedStrings is considered experimental and is subject to change between
+    Julia versions.
 
 ## [Styling](@id stdlib-styledstrings-styling)
 


### PR DESCRIPTION
Four spaces are needed in admonitions, not two.

Amends 8332e457e11fc3feb81ff9d8a1eaf6a500e57124.