### PR TITLE
Fix interpolation edge case dropping annotations

### DIFF
--- a/src/styledmarkup.jl
+++ b/src/styledmarkup.jl
@@ -260,7 +260,7 @@ function addpart!(state::State, start::Int, expr, stop::Int)
             push!(state.parts,
                 :(let $str = string($expr)
                       $len = ncodeunits($str) # Used in `annots`.
-                      if $str isa AnnotatedString && !isempty($str)
+                      if Base._isannotated($str) && !isempty($str)
                           AnnotatedString(String($str), vcat($annots, annotations($str)))
                       else
                           if isempty($str)


### PR DESCRIPTION
It is possible to have types with annotations that should be preserved other than `AnnotatedString` (such as `SubString{AnnotatedString}`), and so we should consult with `Base._isannotated` instead of just checking if the type is an `AnnotatedString` specifically.