### PR TITLE
Add back `*` for 1.10 without needing method overwriting

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -670,3 +670,45 @@ end
     @test printstyled(aio, "e", color=:green)   |> isnothing
     @test read(seekstart(aio), AnnotatedString) == styled"{bold:a}{italic:b}{underline:c}{inverse:d}{(fg=green):e}"
 end
+
+@testset "concatenation via *" begin
+    function check_annotated_equal(a::AbstractString, b::AbstractString)
+        if a isa AnnotatedString && b isa AnnotatedString
+            String(a) == String(b) && annotations(a) == annotations(b)
+        else
+            false
+        end
+    end
+
+    s_annot = styled"{red:hello}"
+    
+    # Test (styled, styled)
+    @test check_annotated_equal(
+        s_annot * styled"{blue:world}",
+        styled"{red:hello}{blue:world}"
+    )
+
+    # Test (styled, regular)
+    @test check_annotated_equal(
+        s_annot * "world",
+        styled"{red:hello}world"
+    )
+
+    # Test (regular, styled)
+    @test check_annotated_equal(
+        "hello" * s_annot,
+        styled"hello{red:hello}"
+    )
+
+    # Test (styled, regular, styled)
+    @test check_annotated_equal(
+        s_annot * " " * styled"{blue:world}",
+        styled"{red:hello} {blue:world}"
+    )
+
+    # Test (regular, regular, styled)
+    @test check_annotated_equal(
+        "hello" * " " * s_annot,
+        styled"hello {red:hello}"
+    )
+end


### PR DESCRIPTION
Fixes #102

I define methods up to 32 `*`. Past that point it would fall back to a regular `String`. While that is obviously not as nice as having the same behavior for all number of arguments, I think it's a far less painful inconsistency than the one reported in #102, so is worth it.