### PR TITLE
Introduce `FaceRef` and use it to wrap any un-resolved `Face`s

### DIFF
--- a/src/regioniterator.jl
+++ b/src/regioniterator.jl
@@ -29,11 +29,12 @@ an iterator which provides each substring and the applicable annotations as a
 
 ```jldoctest
 julia> collect(StyledStrings.eachregion(AnnotatedString(
-           "hey there", [(1:3, :face, :bold), (5:9, :face, :italic)])))
+           "hey there", [(1:3, :face, StyledStrings.FaceRef(:bold)),
+                         (5:9, :face, StyledStrings.FaceRef(:italic))])))
 3-element Vector{Tuple{SubString{String}, Vector{@NamedTuple{label::Symbol, value}}}}:
- ("hey", [@NamedTuple{label::Symbol, value}((:face, :bold))])
+ ("hey", [@NamedTuple{label::Symbol, value}((:face, StyledStrings.FaceRef(:bold)))])
  (" ", [])
- ("there", [@NamedTuple{label::Symbol, value}((:face, :italic))])
+ ("there", [@NamedTuple{label::Symbol, value}((:face, StyledStrings.FaceRef(:italic)))])
 ```
 """
 function eachregion(s::AnnotatedString, subregion::UnitRange{Int}=firstindex(s):lastindex(s))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,9 +2,9 @@
 
 using Test
 
-using StyledStrings: StyledStrings, Legacy, SimpleColor, FACES, Face,
+using StyledStrings: StyledStrings, Legacy, SimpleColor, FACES, Face, FaceRef,
     @styled_str, styled, StyledMarkup, eachregion, getface, addface!, loadface!, resetfaces!,
-    AnnotatedString, AnnotatedChar, AnnotatedIOBuffer, annotations
+    wrap_symbol, AnnotatedString, AnnotatedChar, AnnotatedIOBuffer, annotations
 using .StyledMarkup: MalformedStylingMacro
 
 const NON_STDLIB_TESTS = Main == @__MODULE__
@@ -39,47 +39,47 @@ choppkg(s::String) = chopprefix(s, "StyledStrings.")
     annregions(str::String, annots::Vector{<:Tuple{UnitRange{Int}, Symbol, <:Any}}) =
         [(s, Tuple.(a)) for (s, a) in eachregion(AnnotatedString(str, annots))]
     # Regions that do/don't extend to the left/right edges
-    @test annregions(" abc ", [(2:4, :face, :bold)]) ==
+    @test annregions(" abc ", [(2:4, :face, FaceRef(:bold))]) ==
         [(" ", []),
-         ("abc", [(:face, :bold)]),
+         ("abc", [(:face, FaceRef(:bold))]),
          (" ", [])]
-    @test annregions(" x ", [(2:2, :face, :bold)]) ==
+    @test annregions(" x ", [(2:2, :face, FaceRef(:bold))]) ==
         [(" ", []),
-         ("x", [(:face, :bold)]),
+         ("x", [(:face, FaceRef(:bold))]),
          (" ", [])]
-    @test annregions(" x", [(2:2, :face, :bold)]) ==
+    @test annregions(" x", [(2:2, :face, FaceRef(:bold))]) ==
         [(" ", []),
-         ("x", [(:face, :bold)])]
-    @test annregions("x ", [(1:1, :face, :bold)]) ==
-        [("x", [(:face, :bold)]),
+         ("x", [(:face, FaceRef(:bold))])]
+    @test annregions("x ", [(1:1, :face, FaceRef(:bold))]) ==
+        [("x", [(:face, FaceRef(:bold))]),
          (" ", [])]
-    @test annregions("x", [(1:1, :face, :bold)]) ==
-        [("x", [(:face, :bold)])]
+    @test annregions("x", [(1:1, :face, FaceRef(:bold))]) ==
+        [("x", [(:face, FaceRef(:bold))])]
     # Overlapping/nested regions
-    @test annregions(" abc ", [(2:4, :face, :bold), (3:3, :face, :italic)]) ==
+    @test annregions(" abc ", [(2:4, :face, FaceRef(:bold)), (3:3, :face, FaceRef(:italic))]) ==
         [(" ", []),
-         ("a", [(:face, :bold)]),
-         ("b", [(:face, :bold), (:face, :italic)]),
-         ("c", [(:face, :bold)]),
+         ("a", [(:face, FaceRef(:bold))]),
+         ("b", [(:face, FaceRef(:bold)), (:face, FaceRef(:italic))]),
+         ("c", [(:face, FaceRef(:bold))]),
          (" ", [])]
-    @test annregions("abc-xyz", [(1:7, :face, :bold), (1:3, :face, :green), (4:4, :face, :yellow), (4:7, :face, :italic)]) ==
-        [("abc", [(:face, :bold), (:face, :green)]),
-         ("-", [(:face, :bold), (:face, :yellow), (:face, :italic)]),
-         ("xyz", [(:face, :bold), (:face, :italic)])]
+    @test annregions("abc-xyz", [(1:7, :face, FaceRef(:bold)), (1:3, :face, FaceRef(:green)), (4:4, :face, FaceRef(:yellow)), (4:7, :face, FaceRef(:italic))]) ==
+        [("abc", [(:face, FaceRef(:bold)), (:face, FaceRef(:green))]),
+         ("-", [(:face, FaceRef(:bold)), (:face, FaceRef(:yellow)), (:face, FaceRef(:italic))]),
+         ("xyz", [(:face, FaceRef(:bold)), (:face, FaceRef(:italic))])]
     # Preserving annotation order
-    @test annregions("abcd", [(1:3, :face, :red), (2:2, :face, :yellow), (2:3, :face, :green), (2:4, :face, :blue)]) ==
-        [("a", [(:face, :red)]),
-         ("b", [(:face, :red), (:face, :yellow), (:face, :green), (:face, :blue)]),
-         ("c", [(:face, :red), (:face, :green), (:face, :blue)]),
-         ("d", [(:face, :blue)])]
-    @test annregions("abcd", [(2:4, :face, :blue), (1:3, :face, :red), (2:3, :face, :green), (2:2, :face, :yellow)]) ==
-        [("a", [(:face, :red)]),
-         ("b", [(:face, :blue), (:face, :red), (:face, :green), (:face, :yellow)]),
-         ("c", [(:face, :blue), (:face, :red), (:face, :green)]),
-         ("d", [(:face, :blue)])]
+    @test annregions("abcd", [(1:3, :face, FaceRef(:red)), (2:2, :face, FaceRef(:yellow)), (2:3, :face, FaceRef(:green)), (2:4, :face, FaceRef(:blue))]) ==
+        [("a", [(:face, FaceRef(:red))]),
+         ("b", [(:face, FaceRef(:red)), (:face, FaceRef(:yellow)), (:face, FaceRef(:green)), (:face, FaceRef(:blue))]),
+         ("c", [(:face, FaceRef(:red)), (:face, FaceRef(:green)), (:face, FaceRef(:blue))]),
+         ("d", [(:face, FaceRef(:blue))])]
+    @test annregions("abcd", [(2:4, :face, FaceRef(:blue)), (1:3, :face, FaceRef(:red)), (2:3, :face, FaceRef(:green)), (2:2, :face, FaceRef(:yellow))]) ==
+        [("a", [(:face, FaceRef(:red))]),
+         ("b", [(:face, FaceRef(:blue)), (:face, FaceRef(:red)), (:face, FaceRef(:green)), (:face, FaceRef(:yellow))]),
+         ("c", [(:face, FaceRef(:blue)), (:face, FaceRef(:red)), (:face, FaceRef(:green))]),
+         ("d", [(:face, FaceRef(:blue))])]
     # Region starting after a character spanning multiple codepoints.
-    @test annregions("𝟏x", [(1:4, :face, :red)]) ==
-        [("𝟏", [(:face, :red)]),
+    @test annregions("𝟏x", [(1:4, :face, FaceRef(:red))]) ==
+        [("𝟏", [(:face, FaceRef(:red))]),
          ("x", [])]
 end
 
@@ -342,16 +342,16 @@ end
     @test styled"some {thing=val:string}" == AnnotatedString("some string", [(6:11, :thing, "val")])
     @test styled"some {a=1:s}trin{b=2:g}" == AnnotatedString("some string", [(6:6, :a, "1"), (11:11, :b, "2")])
     @test styled"{thing=val with spaces:some} string" == AnnotatedString("some string", [(1:4, :thing, "val with spaces")])
-    @test styled"{aface:some} string" == AnnotatedString("some string", [(1:4, :face, :aface)])
+    @test styled"{aface:some} string" == AnnotatedString("some string", [(1:4, :face, FaceRef(:aface))])
     # Annotation prioritisation
     @test styled"{aface,bface:some} string" ==
-        AnnotatedString("some string", [(1:4, :face, :aface), (1:4, :face, :bface)])
+        AnnotatedString("some string", [(1:4, :face, FaceRef(:aface)), (1:4, :face, FaceRef(:bface))])
     @test styled"{aface:{bface:some}} string" ==
-        AnnotatedString("some string", [(1:4, :face, :aface), (1:4, :face, :bface)])
+        AnnotatedString("some string", [(1:4, :face, FaceRef(:aface)), (1:4, :face, FaceRef(:bface))])
     @test styled"{aface,bface:$(1)} string" ==
-        AnnotatedString("1 string", [(1:1, :face, :aface), (1:1, :face, :bface)])
+        AnnotatedString("1 string", [(1:1, :face, FaceRef(:aface)), (1:1, :face, FaceRef(:bface))])
     @test styled"{aface:{bface:$(1)}} string" ==
-        AnnotatedString("1 string", [(1:1, :face, :aface), (1:1, :face, :bface)])
+        AnnotatedString("1 string", [(1:1, :face, FaceRef(:aface)), (1:1, :face, FaceRef(:bface))])
     # Inline face attributes
     @test styled"{(slant=italic):some} string" ==
         AnnotatedString("some string", [(1:4, :face, Face(slant=:italic))])
@@ -387,15 +387,15 @@ end
     @test styled"some string\}" == AnnotatedString("some string}")
     @test styled"some \{string\}" == AnnotatedString("some {string}")
     @test styled"some \{str:ing\}" == AnnotatedString("some {str:ing}")
-    @test styled"some \{{bold:string}\}" == AnnotatedString("some {string}", [(7:12, :face, :bold)])
-    @test styled"some {bold:string \{other\}}" == AnnotatedString("some string {other}", [(6:19, :face, :bold)])
+    @test styled"some \{{bold:string}\}" == AnnotatedString("some {string}", [(7:12, :face, FaceRef(:bold))])
+    @test styled"some {bold:string \{other\}}" == AnnotatedString("some string {other}", [(6:19, :face, FaceRef(:bold))])
     # Nesting
     @test styled"{bold:nest{italic:ed st{red:yling}}}" ==
         AnnotatedString(
-            "nested styling", [(1:14, :face, :bold), (5:14, :face, :italic), (10:14, :face, :red)])
+            "nested styling", [(1:14, :face, FaceRef(:bold)), (5:14, :face, FaceRef(:italic)), (10:14, :face, FaceRef(:red))])
     # Production of a `(AnnotatedString)` value instead of an expression when possible
     @test AnnotatedString("val") == @macroexpand styled"val"
-    @test AnnotatedString("val", [(1:3, :face, :style)]) == @macroexpand styled"{style:val}"
+    @test AnnotatedString("val", [(1:3, :face, FaceRef(:style))]) == @macroexpand styled"{style:val}"
     # Interpolation
     let annotatedstring = GlobalRef(StyledMarkup, :annotatedstring)
         AnnotatedString = GlobalRef(StyledMarkup, :AnnotatedString)
@@ -410,14 +410,14 @@ end
         @test :($annotatedstring(val)) == @macroexpand styled"$val"
         @test :($chain($annotatedstring("a", val), $annotatedstring_optimize!)) == @macroexpand styled"a$val"
         @test :($chain($annotatedstring("a", val, "b"), $annotatedstring_optimize!)) == @macroexpand styled"a$(val)b"
-        # @test :($annotatedstring(StyledStrings.AnnotatedString(string(val), $(Pair{Symbol, Any}(:face, :style))))) ==
+        # @test :($annotatedstring(StyledStrings.AnnotatedString(string(val), $(Pair{Symbol, Any}(:face, FaceRef(:style)))))) ==
         #     @macroexpand styled"{style:$val}"
         @test :($annotatedstring($AnnotatedString(
-            "val", [$merge((; region=$(1:3)), $NamedTupleLV((:face, face)))]))) ==
+            "val", [$merge((; region=$(1:3)), $NamedTupleLV((:face, $wrap_symbol(face))))]))) ==
             @macroexpand styled"{$face:val}"
         @test :($chain($annotatedstring($AnnotatedString(
-            "v1v2", [$merge((; region=$(1:2)), $NamedTupleLV((:face, f1))),
-                     $merge((; region=$(3:4)), $NamedTupleLV((:face, f2)))])),
+            "v1v2", [$merge((; region=$(1:2)), $NamedTupleLV((:face, $wrap_symbol(f1)))),
+                     $merge((; region=$(3:4)), $NamedTupleLV((:face, $wrap_symbol(f2))))])),
                        $annotatedstring_optimize!)) ==
             @macroexpand styled"{$f1:v1}{$f2:v2}"
         @test :($annotatedstring($AnnotatedString(
@@ -570,9 +570,9 @@ end
     end
     # AnnotatedChar
     @test sprint(print, AnnotatedChar('a')) == "a"
-    @test sprint(print, AnnotatedChar('a', [(:face, :red)]), context = :color => true) == "\e[31ma\e[39m"
+    @test sprint(print, AnnotatedChar('a', [(:face, FaceRef(:red))]), context = :color => true) == "\e[31ma\e[39m"
     @test sprint(show, AnnotatedChar('a')) == "'a'"
-    @test sprint(show, AnnotatedChar('a', [(:face, :red)]), context = :color => true) == "'\e[31ma\e[39m'"
+    @test sprint(show, AnnotatedChar('a', [(:face, FaceRef(:red))]), context = :color => true) == "'\e[31ma\e[39m'"
     # Might as well put everything together for a final test
     fancy_string = styled"The {magenta:`{green:StyledStrings}`} package {italic:builds}\
         {bold: on top} of the {magenta:`{green:AnnotatedString}`} {link={https://en.wikipedia.org/wiki/Type_system}:type} \


### PR DESCRIPTION
Take 2 on https://github.com/JuliaLang/StyledStrings.jl/pull/99 (solves the same type-piracy problem without changing the face-resolution semantics). This will allow us to dispatch into StyledStrings for display of these Faces / annotations.

I'm still not a fan of the lazy resolution semantics here (I would prefer to have a separate `lazystyled` macro for the delayed resolution / user-customizable styling), but one way or another this type-piracy needs to be resolved.