### PR TITLE
Clarify merge docstring

### DIFF
--- a/src/faces.jl
+++ b/src/faces.jl
@@ -503,10 +503,11 @@ withfaces(f) = f()
 ## Face combination and inheritance ##
 
 """
-    merge(initial::Face, others::Face...)
+    merge(initial::StyledStrings.Face, others::StyledStrings.Face...)
 
-Merge the properties of the `initial` face and `others`, with
-later faces taking priority.
+Merge the properties of the `initial` face and `others`, with later faces taking priority.
+
+This is used to combine the styles of multiple faces, and to resolve inheritance.
 """
 function Base.merge(a::Face, b::Face)
     if isempty(b.inherit)


### PR DESCRIPTION
Considering this is loaded as part of REPL, not specifying that `Face` comes from `StyledStrings` can make the docstring a bit confusing to those not familiar with the stdlib.