### PR TITLE
Adjust parsing of incomplete active styles

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -386,6 +386,11 @@ end
             "val", [$merge((; region=$(1:3)), $NamedTupleLV((:face, $(Face)(foreground = color))))]))) ==
             @macroexpand styled"{(foreground=$color):val}"
     end
+    # Partial annotation termination with interpolation
+    @test styled"{green:a}{red:{blue:b}$('c')}" ==
+        AnnotatedString{String}("abc", [(1:1, :face, :green),
+                                        (2:3, :face, :red),
+                                        (2:2, :face, :blue)])
 
     # Trailing (and non-trailing) Backslashes
     @test String(styled"\\") == "\\"


### PR DESCRIPTION
Instead of applying active styles strictly after pending styles, which is in danger of overriding more specific pending regions, convert active regions into appropriate pending regions before specificity-sorting.

Fixes #111