### PR TITLE
fix method invalidations in legacy by adding @nospecialize

### DIFF
--- a/src/legacy.jl
+++ b/src/legacy.jl
@@ -124,6 +124,7 @@ function load_env_colors!()
 end
 
 function Base.printstyled(io::AnnotatedIOBuffer, @nospecialize(msg...);
+
                           bold::Bool=false, italic::Bool=false, underline::Bool=false,
                           blink::Bool=false, reverse::Bool=false, hidden::Bool=false,
                           color::Union{Symbol, Int}=:normal)

--- a/src/legacy.jl
+++ b/src/legacy.jl
@@ -123,7 +123,7 @@ function load_env_colors!()
     end
 end
 
-function Base.printstyled(io::AnnotatedIOBuffer, msg...;
+function Base.printstyled(io::AnnotatedIOBuffer, @nospecialize(msg...);
                           bold::Bool=false, italic::Bool=false, underline::Bool=false,
                           blink::Bool=false, reverse::Bool=false, hidden::Bool=false,
                           color::Union{Symbol, Int}=:normal)

--- a/src/legacy.jl
+++ b/src/legacy.jl
@@ -124,7 +124,6 @@ function load_env_colors!()
 end
 
 function Base.printstyled(io::AnnotatedIOBuffer, @nospecialize(msg...);
-
                           bold::Bool=false, italic::Bool=false, underline::Bool=false,
                           blink::Bool=false, reverse::Bool=false, hidden::Bool=false,
                           color::Union{Symbol, Int}=:normal)


### PR DESCRIPTION
problem
extending Base.printstyled for AnnotatedIOBuffer in StyledStrings.Legacy causes many method invalidations due to specialization on msg....

root cause
the variadic msg... argument leads to excessive method instances, which get invalidated when a new method is added.

solution
add @nospecialize(msg...) to avoid unnecessary specialization while keeping behavior unchanged.

impact
- fewer invalidations  
- keeps compatibility  
- minimal change (just one annotation)

testing
- [ ] existing tests pass  
- [ ] printstyled works with AnnotatedIOBuffer  
- [ ] no slowdown in typical usage