### PR TITLE
docs: change anchor from man-* to stdlib-annotated-strings

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -48,7 +48,7 @@ using StyledStrings
 styled"{yellow:hello} {blue:there}"
 ```
 
-## [Annotated Strings](@id man-annotated-strings)
+## [Annotated Strings](@id stdlib-annotated-strings)
 
 It is sometimes useful to be able to hold metadata relating to regions of a
 string. A [`AnnotatedString`](@ref Base.AnnotatedString) wraps another string and


### PR DESCRIPTION
The anchor man-annotated-strings already occurs in Julia's doc/src/manual/strings.md