### PR TITLE
Accept faces from another copy of StyledStrings

### DIFF
--- a/src/theme.jl
+++ b/src/theme.jl
@@ -239,6 +239,42 @@ withfaces(f) = f()
 _mergedface(face::Face) = face
 _mergedface(face::Symbol) = get(Face, FACES.current[], face)
 _mergedface(faces::Vector) = mapfoldl(_mergedface, merge, Iterators.reverse(faces))
+_mergedface(face::Any) = _mergedface(foreignface(face))
+
+"""
+    foreignface(face) -> Face
+
+Rebuild `face`, a `Face` from another copy of StyledStrings, as one of ours.
+
+More than one copy of StyledStrings can be loaded at once: the REPL runs on a private copy
+of the stdlib, which is not necessarily the one user code loads (see `Base.require_stdlib`),
+and only the last loaded copy's `Base.AnnotatedDisplay` hooks are active. A `Face` the REPL
+attaches to its output (its bracket highlighting, say) then reaches `getface` as a value of a
+type that is not our `Face`, but has the same fields, holding values of Base types or of the
+other copy's `SimpleColor`.
+"""
+function foreignface(face)
+    T = typeof(face)
+    if nameof(T) === :Face && nameof(parentmodule(T)) === :StyledStrings &&
+        fieldnames(T) == fieldnames(Face)
+        color(c) = isnothing(c) ? nothing : SimpleColor(c.value)
+        underline = face.underline
+        return Face(font = face.font, height = face.height,
+                    weight = face.weight, slant = face.slant,
+                    foreground = color(face.foreground),
+                    background = color(face.background),
+                    underline = if underline isa Tuple
+                        (color(underline[1]), underline[2])
+                    elseif underline isa Union{Nothing, Bool}
+                        underline
+                    else
+                        color(underline)
+                    end,
+                    strikethrough = face.strikethrough, inverse = face.inverse,
+                    inherit = face.inherit)
+    end
+    throw(MethodError(_mergedface, (face,)))
+end
 
 """
     getface(faces)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -645,3 +645,53 @@ end
     @test printstyled(aio, "e", color=:green)   |> isnothing
     @test read(seekstart(aio), AnnotatedString) == styled"{bold:a}{italic:b}{underline:c}{inverse:d}{(fg=green):e}"
 end
+
+# A look-alike for another copy of StyledStrings, whose `Face` is a distinct type with the
+# same fields.
+module OtherCopy
+    module StyledStrings
+        struct SimpleColor
+            value::Union{Symbol, NamedTuple}
+        end
+        struct Face
+            font; height; weight; slant; foreground; background
+            underline; strikethrough; inverse; inherit
+        end
+    end
+end
+
+@testset "Faces from another copy of StyledStrings" begin
+    # The REPL runs on a private copy of StyledStrings, so the faces it attaches to its
+    # output can reach the copy user code loaded as values of a foreign `Face` type
+    # (JuliaLang/julia#60034).
+    Other = OtherCopy.StyledStrings
+    other = Other.Face(nothing, nothing, :bold, nothing, Other.SimpleColor(:red),
+                       Other.SimpleColor((r=0x01, g=0x02, b=0x03)),
+                       (Other.SimpleColor(:blue), :curly), nothing, true, [:emphasis])
+    ours = Face(weight=:bold, foreground=:red, background=(r=0x01, g=0x02, b=0x03),
+                underline=(:blue, :curly), inverse=true, inherit=:emphasis)
+    @test StyledStrings.foreignface(other) == ours
+    @test getface([other]) == getface([ours])
+    @test getface([:emphasis, other]) == getface([:emphasis, ours])
+    @test getface(AnnotatedString("x", [(1:1, :face, other)]), 1) == getface([ours])
+    @test sprint(print, AnnotatedString("x", [(1:1, :face, other)]); context = :color => true) ==
+        sprint(print, AnnotatedString("x", [(1:1, :face, ours)]); context = :color => true)
+    @test_throws MethodError getface([1])
+    let
+        # And with an actual second copy, loaded before ours the way the REPL's is. When the
+        # package under test is the stdlib itself there is no second copy, and the script
+        # reports so instead.
+        script = """
+            other = Base.require_stdlib(Base.PkgId(Base.UUID("f489334b-da3d-4c2e-b8f0-e476e12c162b"), "StyledStrings"))
+            using StyledStrings
+            other === StyledStrings && (print("same copy"); exit())
+            face = other.Face(foreground = :red, weight = :bold)
+            ours = StyledStrings.Face(foreground = :red, weight = :bold)
+            render(f) = sprint(print, Base.AnnotatedString("x", [(1:1, :face, f)]); context = :color => true)
+            print(StyledStrings.getface([face]) == StyledStrings.getface([ours]), ",", render(face) == render(ours))
+            """
+        cmd = `$(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project()) -e $script`
+        out = read(pipeline(cmd; stderr), String)
+        @test out in ("true,true", "same copy")
+    end
+end


### PR DESCRIPTION
Fixes JuliaLang/julia#60034

Claude:

---

More than one copy of StyledStrings can be loaded at once: the REPL runs on a private copy of the stdlib, which is not necessarily the one user code loads (see `Base.require_stdlib`), and only the last loaded copy's `Base.AnnotatedDisplay` hooks are active. A `Face` the REPL attaches to its output, such as LineEdit's bracket highlighting, then reaches `getface` of the other copy as a value of a foreign `Face` type, and every keystroke fails with `MethodError: no method matching _mergedface(::StyledStrings.Face)`. This is what happens in a depot without the bundled stdlib caches, where the first `using` precompiles a second `StyledStrings`.

Such a face is now rebuilt from its fields, which hold Base types or the other copy's `SimpleColor`, whose value is again a Base type. This is the approach tecosaur sketched on the issue; a loader-side fix that reuses the bundled caches would run against the documented meaning of leaving the bundled depot out of `DEPOT_PATH` and the duplication test from JuliaLang/julia#55908.

Tests: one in process with a look-alike module standing in for the other copy, and one in a subprocess that loads a real second copy the way the REPL does, through `Base.require_stdlib`, before the package under test. The subprocess test reports "same copy" and passes vacuously when the package under test is the stdlib itself. Both fail without the fix. Checked in a nightly REPL with this checkout dev'd into the project: `using StyledStrings` followed by typing `(` no longer errors.
